### PR TITLE
fix: kernel panic in release_gpu_memory() due to map->pages

### DIFF
--- a/module/phxfs-mem.c
+++ b/module/phxfs-mem.c
@@ -165,7 +165,8 @@ int phxfs_map_dev_addr_inner(phxfs_mmap_buffer_t mbuffer, u64 devaddr, u64 dev_l
     mbuffer->map->release = release_gpu_memory;
     mbuffer->map->size = dev_len;
     mbuffer->map->gpuvaddr = devaddr;
-    mbuffer->map->n_addrs = mbuffer->dev_page_num; 
+    mbuffer->map->n_addrs = mbuffer->dev_page_num;
+    mbuffer->map->pages = NULL;
     for (i = 0; i < mbuffer->map->n_addrs; ++i)
     {
         mbuffer->map->addrs[i] = 0;


### PR DESCRIPTION
This commit fixes a kernel panic that occurs when calling kfree(map->pages) in release_gpu_memory(). The issue was that map->pages was never initialized in phxfs_map_dev_addr_inner(), leading to an invalid pointer being passed to kfree().

The fix ensures that map->pages is properly initialized to NULL when the p2p_vmap structure is allocated, preventing the kernel from attempting to free uninitialized memory.

Kernel panic details:
- Oops in kfree() with page fault at ffffedda1d5d0008
- Triggered by ./bin/example during GPU memory deregistration
- Call trace shows release_gpu_memory() -> kfree(map->pages)

This resolves the issue reported in #1