### PR TITLE
add support for python api

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,22 @@
+# Python api for phoenix 
+
+This module provide the python api for phoenix.
+
+## Features
+- Use ctypes to wrapper the phoenix api from dynamic library of libphoenix.so
+- Provide a class for phoenix file operations.
+
+## Installation
+
+```bash
+python setup install
+```
+
+## Usage
+
+1. compile the libphoenix.so
+2. deploy the libphoenix.so to /usr/lib64/ or any other library path
+3. python -c "import phxfs;print(phxfs.__file__)"
+
+## License
+Apache-2.0 License

--- a/python/phxfs/__init__.py
+++ b/python/phxfs/__init__.py
@@ -1,0 +1,9 @@
+"""
+phxfs-python - A basic Python wrapper for the phxfs API
+"""
+
+__version__ = "0.1.0"
+
+from .phxfs import Phxfs, PhxfsDriver
+
+__all__ = ["Phxfs", "PhxfsDriver"] 

--- a/python/phxfs/phxfs.py
+++ b/python/phxfs/phxfs.py
@@ -1,0 +1,121 @@
+"""
+Main module for Phxfs file operations.
+"""
+
+import os
+import ctypes
+
+from .phxfs_bind import *
+
+
+def _singleton(cls):
+    _instances = {}
+
+    def wrapper(*args, **kwargs):
+        if cls not in _instances:
+            _instances[cls] = cls(*args, **kwargs)
+        return _instances[cls]
+
+    return wrapper
+
+
+@_singleton
+class PhxfsDriver:
+    def __init__(self, device_id: int):
+        self.device_id = device_id
+        r = phxfs_open(device_id)
+        if r != 0:
+            raise RuntimeError("open phxfs error %d".format(r))
+
+    def __del__(self):
+        r = phxfs_close(self.device_id)
+        if r != 0:
+            raise RuntimeError("open phxfs error %d".format(r))
+
+
+def _os_mode(mode: str):
+    modes = {
+        "r": os.O_RDONLY,
+        "r+": os.O_RDWR,
+        "w": os.O_CREAT | os.O_WRONLY | os.O_TRUNC,
+        "w+": os.O_CREAT | os.O_RDWR | os.O_TRUNC,
+        "a": os.O_CREAT | os.O_WRONLY | os.O_APPEND,
+        "a+": os.O_CREAT | os.O_RDWR | os.O_APPEND,
+    }
+    return modes[mode]
+
+
+class Phxfs:
+    """
+    Main class for Phxfs file operations.
+    """
+
+    def __init__(self, path: str, mode: str = "r", use_direct_io: bool = False, device_id = 0):
+        """
+        Initialize the Phxfs instance.
+        """
+        self._device_id = device_id
+        self._path = path
+        self._mode = mode
+        self._os_mode = _os_mode(mode)
+        if use_direct_io:
+            self._os_mode |= os.O_DIRECT
+
+        self._handle = None
+
+    def __del__(self):
+        """
+        Destructor to ensure the file is closed.
+        """
+        if self.is_open:
+            self.close()
+
+    @property
+    def is_open(self) -> bool:
+        return self._handle is not None
+
+    def open(self):
+        """Opens the file and registers the handle."""
+        if self.is_open:
+            return
+        self._handle = os.open(self._path, self._os_mode)
+        self.phxfs_fileid = phxfs_fileid_t(fd=self._handle, deviceID=self._device_id)
+
+    def close(self):
+        """Deregisters the handle and closes the file."""
+        if not self.is_open:
+            return
+
+        os.close(self._handle)
+        self._handle = None
+
+    def regmem(self, addr, nbytes, target_addr):
+        return phxfs_regmem(self._device_id, addr, nbytes, target_addr)
+
+    def deregmem(self, addr, nbytes):
+        return phxfs_deregmem(self._device_id, addr, nbytes)
+
+    def __enter__(self):
+        """Context manager entry."""
+        self.open()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Context manager exit."""
+        self.close()
+
+    def read(self, dest: ctypes.c_void_p, size: int, file_offset: int = 0, dev_offset: int = 0):
+        """Read from the file."""
+        if not self.is_open:
+            raise IOError("File is not open.")
+        return phxfs_read(self.phxfs_fileid, dest, dev_offset, size, file_offset)
+
+    def write(self, src: ctypes.c_void_p, size: int, file_offset: int = 0, dev_offset: int = 0):
+        """Write to the file."""
+        if not self.is_open:
+            raise IOError("File is not open.")
+        return phxfs_write(self.phxfs_fileid, src, dev_offset, size, file_offset)
+
+    def get_handle(self):
+        """Get the file handle."""
+        return self._handle

--- a/python/phxfs/phxfs_bind.py
+++ b/python/phxfs/phxfs_bind.py
@@ -1,0 +1,88 @@
+import ctypes
+import os
+
+ctypes.CDLL("libcudart.so", mode=ctypes.RTLD_GLOBAL)
+ctypes.CDLL("libcuda.so", mode=ctypes.RTLD_GLOBAL)
+ctypes.CDLL("libphoenix.so", mode=ctypes.RTLD_GLOBAL)
+
+libphxfs = ctypes.CDLL("libphoenix.so")
+cuda = ctypes.CDLL("libcuda.so")
+
+class phxfs_fileid_t(ctypes.Structure):
+    _fields_ = [("fd", ctypes.c_int), ("deviceID", ctypes.c_int)]
+class xfer_addr(ctypes.Structure):
+    _fields_ = [("target_addr", ctypes.c_void_p), ("nbyte", ctypes.c_size_t)]
+
+MAX_NR_ADDR = 4
+class phxfs_xfer_addr(ctypes.Structure):
+    _fields_ = [("nr_xfer_addrs", ctypes.c_uint32), ("x_addrs", xfer_addr*1)]
+
+cudaError_t = ctypes.c_int
+
+libphxfs.phxfs_open.restype                   = ctypes.c_int
+libphxfs.phxfs_close.restype                  = ctypes.c_int
+libphxfs.phxfs_read.restype                   = ctypes.c_ssize_t
+libphxfs.phxfs_write.restype                  = ctypes.c_ssize_t
+libphxfs.phxfs_do_xfer_addr.restype           = ctypes.POINTER(phxfs_xfer_addr)
+libphxfs.phxfs_regmem.restype                 = ctypes.c_int
+libphxfs.phxfs_deregmem.restype               = ctypes.c_int
+libphxfs.phxfs_read_async.restype             = cudaError_t
+libphxfs.phxfs_write_async.restype            = cudaError_t
+
+CUstream = ctypes.c_void_p
+
+libphxfs.phxfs_open.argtypes = [ctypes.c_int]
+libphxfs.phxfs_close.argtypes = [ctypes.c_int]
+libphxfs.phxfs_read.argtypes = [phxfs_fileid_t, ctypes.c_void_p, ctypes.c_longlong, ctypes.c_size_t, ctypes.c_longlong]
+libphxfs.phxfs_write.argtypes = [phxfs_fileid_t, ctypes.c_void_p, ctypes.c_longlong, ctypes.c_size_t, ctypes.c_longlong]
+libphxfs.phxfs_do_xfer_addr.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_longlong, ctypes.c_size_t]
+libphxfs.phxfs_regmem.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_size_t, ctypes.POINTER(ctypes.c_void_p)]
+libphxfs.phxfs_deregmem.argtypes = [ctypes.c_int, ctypes.c_void_p, ctypes.c_size_t]
+libphxfs.phxfs_read_async.argtypes = [phxfs_fileid_t, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_longlong, ctypes.POINTER(ctypes.c_ssize_t), CUstream]
+libphxfs.phxfs_write_async.argtypes = [phxfs_fileid_t, ctypes.c_void_p, ctypes.c_size_t, ctypes.c_longlong, ctypes.POINTER(ctypes.c_ssize_t), CUstream]
+
+def _check_ret(ret, name):
+    if ret < 0:
+        raise RuntimeError(f"{name} failed with return code: {ret}")
+def phxfs_open(device_id: int) -> ctypes.c_int:
+    ret = libphxfs.phxfs_open(device_id)
+    _check_ret(ret, "phxfs_open")
+    return ret
+
+def phxfs_close(device_id: int) -> ctypes.c_int:
+    ret = libphxfs.phxfs_close(device_id)
+    _check_ret(ret, "phxfs_close")
+    return ret
+
+def phxfs_read(fid: phxfs_fileid_t, buf: ctypes.c_void_p, buf_offset: ctypes.c_longlong, nbyte: ctypes.c_ssize_t, f_offset: ctypes.c_longlong) -> ctypes.c_ssize_t:
+    ret = libphxfs.phxfs_read(fid, buf,  buf_offset, nbyte, f_offset)
+    if ret < 0:
+        raise RuntimeError(f"phxfs_read failed with return code: {ret}")
+    return ret
+
+def phxfs_write(fid: phxfs_fileid_t, buf: ctypes.c_void_p, buf_offset: ctypes.c_longlong, nbyte: ctypes.c_ssize_t, f_offset: ctypes.c_longlong) -> ctypes.c_ssize_t:
+    ret = libphxfs.phxfs_write(fid, buf, buf_offset, nbyte, f_offset)
+    if ret < 0:
+        raise RuntimeError(f"phxfs_write failed with return code: {ret}")
+    return ret
+
+def phxfs_do_xfer_addr(device_id: ctypes.c_int, buf: ctypes.c_void_p, buf_offset: ctypes.c_longlong, nbyte: ctypes.c_size_t) -> ctypes.POINTER(phxfs_xfer_addr):
+    return libphxfs.phxfs_do_xfer_addr(device_id, buf, buf_offset, nbyte)
+
+def phxfs_regmem(device_id: ctypes.c_int, gpu_buffer: ctypes.c_void_p, len: ctypes.c_size_t, target_addr: ctypes.POINTER(ctypes.c_void_p)) -> ctypes.c_int:
+    ret = libphxfs.phxfs_regmem(device_id, gpu_buffer, len, target_addr)
+    if ret < 0:
+        raise RuntimeError(f"phxfs_regmem failed with return code: {ret}")
+    return ret
+
+def phxfs_deregmem(device_id: ctypes.c_int, addr: ctypes.c_void_p, len: ctypes.c_size_t) -> ctypes.c_int:
+    ret = libphxfs.phxfs_deregmem(device_id, addr, len)
+    if ret < 0:
+        raise RuntimeError(f"phxfs_deregmem failed with return code: {ret}")
+    return ret
+
+def phxfs_read_async(fid: phxfs_fileid_t, buf: ctypes.c_void_p, nbytes: ctypes.c_size_t, offset: ctypes.c_longlong, bytes_done: ctypes.c_ssize_t, stream: CUstream) -> cudaError_t:
+    return libphxfs.phxfs_read_async(fid, buf, nbytes, offset, bytes_done, stream)
+
+def phxfs_write_async(fid: phxfs_fileid_t, buf: ctypes.c_void_p, nbytes: ctypes.c_size_t, offset: ctypes.c_longlong, bytes_done: ctypes.c_ssize_t, stream: CUstream) -> cudaError_t:
+    return libphxfs.phxfs_write_async(fid, buf, nbytes, offset, bytes_done, stream)

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,20 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='phxfs',
+    version='0.1.2',
+    packages=find_packages(),
+    author='kuangkai',
+    author_email='kuangkai@kylinos.cn',
+    description='The python module of phoenix api',
+    long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
+    url='https://github.com/nicexlab/phoenix',
+    classifiers=[
+        'Programming Language :: Python :: 3',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+    ],
+    python_requires='>=3.7',
+)
+

--- a/python/test/test.py
+++ b/python/test/test.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+import torch
+import os
+import sys
+import time
+import ctypes
+
+from phxfs import PhxfsDriver, Phxfs
+from lmcache.v1.memory_management import GPUMemoryAllocator
+
+DEVICE_ID = 0 # only support the device id 0 for now.
+DATA_PATH = '/mnt/phxfs/data.bin'
+
+class PhxfsMemoryAllocator(GPUMemoryAllocator):
+    def __init__(self, size: int, device=None):
+        from phxfs.phxfs_bind import phxfs_regmem, phxfs_deregmem
+
+        self.phxfsBufDeReg = phxfs_deregmem
+        if device is None:
+            if torch.cuda.is_available():
+                device = f"cuda:{torch.cuda.current_device()}"
+            else:
+                device = "cpu:0"
+        super().__init__(size, device, align_bytes=4096)
+        self.size = size
+        self.device = DEVICE_ID 
+        self.base_pointer = self.tensor.data_ptr()
+        void_ptr = ctypes.c_void_p()
+        host_ptr = ctypes.POINTER(ctypes.c_void_p)(void_ptr)
+        phxfs_regmem(self.device, ctypes.c_void_p(self.base_pointer), ctypes.c_size_t(self.size), host_ptr)
+        self.host_ptr = void_ptr
+
+    def __del__(self):
+        self.phxfsBufDeReg(self.device, ctypes.c_void_p(self.base_pointer), ctypes.c_size_t(self.size))
+
+    def __str__(self):
+        return "PhxfsMemoryAllocator"
+
+
+if __name__ == "__main__":
+
+
+    phxfs_driver = PhxfsDriver(DEVICE_ID)
+
+    shape = torch.Size([2, 36, 256, 1024])
+    dtype = torch.bfloat16 
+    alloc = PhxfsMemoryAllocator(37748736, device="cuda:%d" % DEVICE_ID)
+
+    
+    with Phxfs(DATA_PATH, "r", use_direct_io=True, device_id=DEVICE_ID) as f:
+        start = time.time()
+        r = f.read(
+            alloc.base_pointer,
+            37748736,
+            file_offset=0,
+            dev_offset=0,
+        )
+        load_du = time.time() - start
+        print(f"read data take {load_du:.6f}s")
+
+    alloc = None
+    phxfs_driver = None


### PR DESCRIPTION
the python api of phoenix can be used in vllm lmcache to improve the performance of kvcache offloading

this pull request solved the issue #5  


usage:
1. build and deploy the libphoenix.so
`mkdir build ; cd build;  cmake ../ && make`
`cp module/libphoenix.so /usr/lib64/`
2. test the python api
`cd python; python setup install`
python test.py
read data take 0.006597s
