### PR TITLE
fix:Keep the read buffer address fixed to improve performance

### DIFF
--- a/benchmarks/micro-benchmarks/posix_test.cc
+++ b/benchmarks/micro-benchmarks/posix_test.cc
@@ -58,7 +58,7 @@ static void *read_thread(void *arg) {
     while (read_bytes < data->size) {
         clock_gettime(CLOCK_MONOTONIC, &io_start); 
         result = pread(fd, 
-            point_offset(data->buffer, read_bytes), 
+            data->buffer,
             data->io_size, data->offset + read_bytes);
         if (result == 0) {
             // End of file reached
@@ -69,8 +69,8 @@ static void *read_thread(void *arg) {
             return NULL;
         }
         check_cudaruntimecall(cudaMemcpy(
-            point_offset(data->gpu_buffer, data->offset + read_bytes),
-            point_offset(data->buffer, read_bytes), 
+            data->gpu_buffer,
+            data->buffer,
             data->io_size, cudaMemcpyHostToDevice));
         check_cudaruntimecall(cudaStreamSynchronize(0));
         clock_gettime(CLOCK_MONOTONIC, &io_end);


### PR DESCRIPTION
When calling pread to read files from disk into memory, if the write address of the memory buffer is moved every time, it will greatly reduce the hit rate of TLB and CPU cache. 
It should be changed to a fixed write address for the memory buffer.
<img width="933" height="717" alt="微信图片_2026-01-20_104759_858" src="https://github.com/user-attachments/assets/4f02deda-372b-4c65-b847-33ed56924d16" />
